### PR TITLE
[Refactor] use a global variable to get the original BigInt instead of a global property

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var $BigInt = global.BigInt;
+var $BigInt = typeof BigInt !== 'undefined' && BigInt;
 
 module.exports = function hasNativeBigInts() {
 	return typeof $BigInt === 'function'


### PR DESCRIPTION
not all bundlers polyfill the node `global` variable. this change makes the library work universally in node or the browser, whether `global` is polyfilled or not.

a discussion of the issue for a similar library is here: https://github.com/inspect-js/has-symbols/issues/11